### PR TITLE
Update query for 'Search on Github' button

### DIFF
--- a/api/src/pages/vscripts/elements/utils/components.tsx
+++ b/api/src/pages/vscripts/elements/utils/components.tsx
@@ -81,7 +81,7 @@ const SearchWrapper = styled.a.attrs({ target: "_blank", rel: "noreferrer noopen
 `;
 
 export const SearchOnGitHub: React.FC<{ name: string }> = ({ name }) => {
-  const query = encodeURIComponent(`vscripts in:path ${name} in:file`);
+  const query = encodeURIComponent(`${name} path:vscripts`);
   const href = `https://github.com/search?l=Lua&q=${query}&type=Code`;
   return (
     <SearchWrapper href={href} title="Search on GitHub">


### PR DESCRIPTION
Github advanced search changed syntax at some point, and `vscripts in:path in:file` returns nothing. The updated syntax is `path:vscripts`.