### PR TITLE
fix transmitter example not refreshing values

### DIFF
--- a/_articles/abilities/server-to-client.md
+++ b/_articles/abilities/server-to-client.md
@@ -117,12 +117,15 @@ end
 
 --refresh the modifier on every think
 function modifier_example:OnIntervalThink()
-	self:ForceRefresh()
+	self:OnRefresh()
 end
 
 --this function is called when a modifier is reapplied, or manually refreshed in a script.
 function modifier_example:OnRefresh( kv )
 	if IsServer() then
+    --call OnCreated again to recalculate our values
+    self:OnCreated()
+    
 		--SendBuffRefreshToClients is a server-only function
 		self:SendBuffRefreshToClients()
 	end


### PR DESCRIPTION
was using `ForceRefresh` every interval think which made modifiers have endless duration
changed to just `self:OnRefresh()`

and added missing call to `self:OnCreated()`