### PR TITLE
fix lava damage tutorial

### DIFF
--- a/_articles/scripting/lava-damage.md
+++ b/_articles/scripting/lava-damage.md
@@ -11,43 +11,101 @@ Today we going to create Lava area when a hero step on that lava he will get dam
 
 
 **First you need to create a block and assign trigger texture to it**
+
+First press Shift+B and drag your desired box for the lava area.
+
+Once you've created your Block, we have to assign it a trigger material.  
+This can be done by going to the material library and name filtering "trigger", then drag and drop this material onto the block.  
+It should change to the specified (trigger) material.
+
 <Gfycat id="WaterloggedQuarrelsomeDutchshepherddog" />
 
-Then convert the mesh to Entity and name it plus assign this Entity script to lavatrigger.lua <-- you can name it whatever you want.
+Then convert the mesh to Entity by pressing Ctrl+T or find the `Outliner` => Right Click => Selected Meshes => Tie to Entity.
+Afterwards, name it plus assign this Entity script to lavatrigger.lua <-- you can name it whatever you want.
 
 ![](https://i.imgur.com/5eZycip.png)
 
-<Gfycat id="AntiqueSkinnyKagu" />
+Next we go to Outputs tabs in top and click on it add the following in the picture.
 
-next we go to Outputs tabs in top and click on it add the following in the picture.
-
-![](https://i.imgur.com/gPZY3Us.png)
+![](https://i.imgur.com/nvr9nhv.png)
 
 Now go to your vscript folder and create a file called lavatrigger.lua and put this script inside.
+
 ```lua
-local LAVA_DAMAGE_TICK_RATE = 2
-local LAVA_DAMAGE_AMOUNT = 100
+LAVA_MODIFIER_NAME = "lava_modifier"
+LAVA_DAMAGE_AMOUNT = 10
 
-function lavatrigger(trigger)
+lava_modifier = lava_modifier or class({})
 
-        local ent = trigger.activator
+local LAVA_DAMAGE_TICK_RATE = 0.5
 
-        if not ent then return end
+function lava_modifier:IsHidden()
+    return true
+end
 
-        local hp = ent:GetHealth()
+function lava_modifier:IsPurgable()
+    return false
+end
 
-        if hp >= LAVA_DAMAGE_AMOUNT then
-            ent:SetHealth(hp - LAVA_DAMAGE_AMOUNT)
-        else
-            ent:ForceKill(true)
+function lava_modifier:IsDebuff()
+    return false
+end
+
+function lava_modifier:DeclareFunctions()
+    local funcs = {}
+    return funcs
+end
+
+-- Modifiers exist both on server and client, so take care what methods you use
+function lava_modifier:OnCreated()
+    if IsServer() then
+        self:SetStackCount(0)
+        self:StartIntervalThink(LAVA_DAMAGE_TICK_RATE)
+    end
+end
+
+function lava_modifier:OnIntervalThink()
+    if IsServer() then
+        if self:GetStackCount() > 0 then
+            local ent = self:GetCaster()
+            local damageTable = {
+                victim = ent,
+                attacker = ent,
+                damage = LAVA_DAMAGE_AMOUNT,
+                damage_type = DAMAGE_TYPE_PURE,
+            }
+            ApplyDamage(damageTable)
         end
+    end
+end
 
-    return LAVA_DAMAGE_TICK_RATE
+LinkLuaModifier(LAVA_MODIFIER_NAME, "lavatrigger", LUA_MODIFIER_MOTION_NONE)
+
+function applyLava(trigger, delta)
+    if not IsServer() then
+        return
+    end
+
+    local ent = trigger.activator
+
+    if not ent then
+        return
+    end
+    if not ent:HasModifier(LAVA_MODIFIER_NAME) then
+        ent:AddNewModifier(ent, nil, LAVA_MODIFIER_NAME, nil)
+    end
+    local originalStacks = ent:GetModifierStackCount(LAVA_MODIFIER_NAME, nil)
+    local newStacks = originalStacks + delta
+    ent:SetModifierStackCount(LAVA_MODIFIER_NAME, ent, newStacks)
+end
+
+function lavaEnter(trigger)
+    applyLava(trigger, 1)
+end
+
+function lavaExit(trigger)
+    applyLava(trigger, -1)
 end
 ```
 
-here is the final result!:smile: 
-<Gfycat id="CharmingTestyAlaskanmalamute" />
-
-
-NOTE We can spice this a little bit with particles effect and sound will explain that next time.
+You should be done!


### PR DESCRIPTION
Fixes the tutorial to work

Adds an explanation on how to create the trigger area.

Remove RedGifs link
- info is redundant, and that host seems to specialize in porn gifs....