### PR TITLE
Updated the Add-a-hitbox tutorial

### DIFF
--- a/_articles/assets/models/adding-hitbox-to-models-without-a-bone.md
+++ b/_articles/assets/models/adding-hitbox-to-models-without-a-bone.md
@@ -3,67 +3,56 @@ title: Adding Hitbox to Models without a Bone
 author: Noya
 steamId: '76561198046984233'
 date: 06.12.2015
+[//]: <> (updated-by: Abraham Blinkin' 12.10.2023)
 ---
 
 If you tried some of Valve's prop models, you had already noticed that many of them don't have a hitbox, so they can't be used for selectable units.
 
 There is a very easy process that takes no longer than a couple of minutes to add one. 
 
-In this tutorial, I will add a hitbox to this model: `gryphon_statue001.vmdl`
+In this tutorial, I will add a hitbox to this model: `gryphon_statue001.vmdl.`
 
 ![img](https://puu.sh/lLH62/45243b2ded.jpg)
 
-As you can see after selecting `Display -> Hitboxes`, it has no hitbox, so it can't be clicked on ingame.
-
 ## Step 1. Hammer DMX Export
 
-Open Hammer, make a new map, and drag the model into the origin.
+Open Hammer, make a new map ( File->New or CTRL+N ), and drag the model into the origin. 
 
 ![img](https://puu.sh/lLHek/b90cae10f2.png)
 
-You can also rotate or displace it if its required, as well as adding more models to the scene.
+You can also rotate, scale, or displace it as required.
 
-After its done, go to **File -> Export Files** or **Export Selected**, and save the file as **.dmx** inside the models folder.
+After its done, select the model and right-click on it. Then under the **Selected Objects** options, click **Create Model From Selection**. Save to your **Models** directory. Bear in mind that you can select multiple mesh in the viewport and export them as a single model, but their textures will not properly export with them.
 
 ## Step 2. Generate a VMDL
 
-Open the Model Editor and select **New VMDL From Mesh File** option, and choose your recently generated .dmx file
+Search for your new model in the Asset Browser and double-click it to open.
 
-![img](https://puu.sh/lLHwg/89b5353d2a.png)
+![img](https://i.imgur.com/l12Ub1w.png)
 
-![img](https://puu.sh/lLHD0/2a3a5ed53b.jpg)
+## Step 3. Download Cube.fbx
 
-Save and close.
-
-## Step 3. Add Cube.fbx hitbox
-
-
-This is a mesh with 1 bone. [Download it directly](/cube.fbx) and put the file in your model folder
-
+This is a mesh with 1 bone. [Download it directly](/cube.fbx) and put the file in your models directory.
 
 Credits to @Internet_Veteran
 
-## Step 4. VMDL Editing
+## Step 4. Add the Cube.fbx a 'Simple Animation'
 
-This is the critical part. Basically you'll be adding the cube mesh into the exported model. You can do this on the model editor (**Animation -> Add Animation**, or by editing the .vmdl file with a text editor and coping the following lines:
+This is the critical part. Basically you'll be adding the cube mesh into the new model. You can do this on the model editor **Add -> Add Simples Animations...** and click "OK." It will ask for an fbx file to add. Choose the Cube.fbx that you placed in your models directory.
 
-https://pastebin.com/qryMBaPz
+## Step 5: The a "Bone"
 
-Just replace everything on your vmdl except for the first big *m_meshList* block
+Now go to **Add -> Bone** and name it 'bone.' 
 
-Restart the workshop tools after that.
+## Step 6: Add and Adjust the "Hitbox"
 
-## Step 5: Open the file and adjust the hitbox
+Now go to **Add -> Hitbox** and choose **(New HitboxSet)** as the parent node, and click "OK." Name the hitbox "hitbox" and click "OK," then choose "bone" as the parent_bone for the hitbox.
 
-The attached cube is a small 50x50 rectangle, just click on it and adjust it to your model needs. You can also edit it directly from the .vmdl file under *m_vMinBounds* and *m_vMaxBounds*
+Now use the blue arrows in the viewport to adjust the size of the hitbox.
 
-**Note:** If your file shows as error, make sure to restart the workshop tools, or repeat the process after deleting all the compiled and source files.
+![img](https://i.imgur.com/pyrL292.png)
 
-Press `T` hotkey to access the scaling tool.
-
-![img](https://puu.sh/lLIGx/4b75817f3f.jpg)
-
-![img](https://puu.sh/lLIN3/8ab9a87b21.jpg)
+Finally, go to **File -> Save and Compile**
 
 That's all! Now your model will have a hitbox ingame:
 

--- a/_articles/tools/adding-bone-to-model-new.md
+++ b/_articles/tools/adding-bone-to-model-new.md
@@ -1,0 +1,13 @@
+---
+title: Adding a Bone to a Model in the new editor
+author: Abraham Blinkin'
+steamId: '76561198072015344'
+date: 12.10.2023
+---
+
+Adding a 'bone' to a model in ModelDoc
+
+`dota_launch_custom_game <addon_name> <map_name>`: Launches the map_name inside the addon_name content folder. This avoids having to open the map in hammer, You can `disconnect` or `restart` at any point.
+
+![img](https://puu.sh/g7Tp0/950028a084.png)
+_host_timescale 10_


### PR DESCRIPTION
The tutorial originally written by Noya was made for the legacy model editor, which is no longer available.